### PR TITLE
Fix compile error in HealthBoostPlugin

### DIFF
--- a/src/main/java/HealthBoostPlugin.java
+++ b/src/main/java/HealthBoostPlugin.java
@@ -47,7 +47,8 @@ public class HealthBoostPlugin extends JavaPlugin implements Listener {
             maxHealth += 2 * increase;
         }
 
-        AttributeInstance healthAttribute = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+        // Updated attribute for newer Paper API versions
+        AttributeInstance healthAttribute = player.getAttribute(Attribute.MAX_HEALTH);
         if (healthAttribute != null && healthAttribute.getBaseValue() != maxHealth) {
             healthAttribute.setBaseValue(maxHealth);
             if (player.getHealth() > maxHealth) {


### PR DESCRIPTION
## Summary
- use `Attribute.MAX_HEALTH` when fetching player attribute

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a8a5dee188320b82af00a09b85af9