### PR TITLE
Enable Folia compatibility

### DIFF
--- a/src/main/java/HealthBoostPlugin.java
+++ b/src/main/java/HealthBoostPlugin.java
@@ -32,7 +32,7 @@ public class HealthBoostPlugin extends JavaPlugin implements Listener {
 
         // サーバーリロード時などに、オンラインの全プレイヤーにModifierを再適用
         for (Player player : getServer().getOnlinePlayers()) {
-            adjustPlayerHealth(player);
+            player.getScheduler().run(this, scheduledTask -> adjustPlayerHealth(player));
         }
         getLogger().info("HealthBoostPlugin enabled. Modifier Key for lookup: " + this.healthBoostModifierKey.toString());
     }
@@ -41,7 +41,7 @@ public class HealthBoostPlugin extends JavaPlugin implements Listener {
     public void onDisable() {
         // プラグイン無効時に、このプラグインが追加したModifierを全プレイヤーから削除
         for (Player player : getServer().getOnlinePlayers()) {
-            removeHealthModifier(player);
+            player.getScheduler().run(this, scheduledTask -> removeHealthModifier(player));
         }
         getLogger().info("HealthBoostPlugin disabled and all custom health modifiers removed.");
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,4 @@ main: com.example.healthboost.HealthBoostPlugin
 version: 1.0
 author: YourName
 api-version: '1.21'
+folia-supported: true


### PR DESCRIPTION
## Summary
- schedule operations for online players through player region scheduler
- mark plugin.yml as folia supported

## Testing
- `mvn -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68459c384988832093b75c88a6cd0831